### PR TITLE
add rasa models folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ venv.bak/
 .mypy_cache/
 
 .DS_Store
+
+# rasa models
+rasa_quick_starter/models


### PR DESCRIPTION
the files in the rasa_quick_starter/models are generated very time one command runs - should be ignored.